### PR TITLE
Execute callback when cancelled

### DIFF
--- a/denops/@ddu-sources/ui_select.ts
+++ b/denops/@ddu-sources/ui_select.ts
@@ -37,6 +37,18 @@ export class Source extends BaseSource<Params> {
     });
   }
 
+  async onEvent(args: {
+    denops: Denops;
+    event: string;
+  }) {
+    if (args.event === "cancel") {
+      await args.denops.call(
+        "luaeval",
+        "require('ddu-vim-ui-select').on_choice({})",
+      );
+    }
+  }
+
   params(): Params {
     return {};
   }


### PR DESCRIPTION
`vim.ui.select()` callback can call with nil when cancelled selection.
This PR makes call this.